### PR TITLE
[Jenkins CI] [Unit tests] optimized unit test failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,10 @@ pipeline {
               )
           }
             failure{
+              xunit (
+                thresholds: [ skipped(failureThreshold: '0'), failed(failureThreshold: '0') ],
+                tools: [ JUnit(pattern: 'target/surefire-reports/*.xml') ]
+              )
               error "Test failure. Stopping pipeline execution!"
             }
             cleanup{


### PR DESCRIPTION
Added a condition to ensure that the reports are still accessible even if the unit tests fail.